### PR TITLE
Keep checkerboard fixation constant

### DIFF
--- a/experiments/FMRI/qc/checkerboard/main.m
+++ b/experiments/FMRI/qc/checkerboard/main.m
@@ -127,28 +127,7 @@ try
         isiDuration = pa.isiSequence(ev);
         isiEnd = GetSecs + isiDuration;
 
-        % Fixation dimming task during ISI
-        if pa.dimSchedule(ev) > 0
-            dimTime = GetSecs + pa.dimSchedule(ev);
-            dimDone = false;
-        else
-            dimTime = Inf;
-            dimDone = true;
-        end
-
         while GetSecs < isiEnd - 0.5 * VP.ifi
-            % Dimming task
-            if ~dimDone && GetSecs >= dimTime && GetSecs < dimTime + pa.dimDuration
-                Screen('FillRect', VP.window, VP.backGroundColor);
-                draw_fixation(VP, pa, pa.fixDimColor);
-                Screen('Flip', VP.window);
-            elseif ~dimDone && GetSecs >= dimTime + pa.dimDuration
-                Screen('FillRect', VP.window, VP.backGroundColor);
-                draw_fixation(VP, pa, pa.fixColor);
-                Screen('Flip', VP.window);
-                dimDone = true;
-            end
-
             % Check escape
             [pressed, firstPress] = KbQueueCheck();
             if pressed && firstPress(kb.escKey)

--- a/experiments/FMRI/qc/checkerboard/utils/setup/load_checkerboard_design.m
+++ b/experiments/FMRI/qc/checkerboard/utils/setup/load_checkerboard_design.m
@@ -26,8 +26,8 @@ design.isiMax = 12;                   % seconds
 design.nEvents = 27;
 design.initialBaselineDuration = 10;  % seconds
 design.finalBaselineDuration = 10;    % seconds
-design.dimDuration = 0.3;             % seconds
-design.dimFraction = 0.3;
+design.dimDuration = 0;               % fixation remains red throughout
+design.dimFraction = 0;
 
 targetIsiSum = design.targetRunDuration - ...
     design.initialBaselineDuration - design.finalBaselineDuration - ...
@@ -61,11 +61,6 @@ design.totalDesignDuration = design.initialBaselineDuration + ...
     design.finalBaselineDuration;
 
 design.dimSchedule = zeros(1, design.nEvents);
-dimTrials = randperm(design.nEvents, round(design.nEvents * design.dimFraction));
-for i = dimTrials
-    maxDimOnset = max(0.5, design.isiSequence(i) - design.dimDuration - 0.5);
-    design.dimSchedule(i) = 0.5 + (maxDimOnset - 0.5) * rand();
-end
-design.dimTrials = dimTrials;
+design.dimTrials = [];
 
 end

--- a/experiments/FMRI/qc/checkerboard/utils/setup/setup_param.m
+++ b/experiments/FMRI/qc/checkerboard/utils/setup/setup_param.m
@@ -51,14 +51,14 @@ pa.nRings = 10;                 % number of concentric rings (log-spaced)
 pa.nWedges = 24;                % number of angular wedges
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% FIXATION DOT & DIMMING TASK
+% FIXATION CROSS
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-pa.fixCrossLenDeg = 0.25;       % arm length in degrees
+pa.fixCrossLenDeg = 0.20;       % arm length in degrees
 pa.fixCrossLen = max(4, round(pa.fixCrossLenDeg * VP.pixelsPerDegree));
 pa.fixCrossWidth = 2;           % line width in pixels
 pa.fixColor = [255 0 0];        % red cross
-pa.fixDimColor = [80 0 0];      % dim red (target)
-pa.dimDuration = design.dimDuration;  % seconds the cross stays dim
+pa.fixDimColor = pa.fixColor;   % fixation remains red throughout
+pa.dimDuration = design.dimDuration;
 pa.dimSchedule = design.dimSchedule;
 dimTrials = design.dimTrials;
 
@@ -103,6 +103,6 @@ fprintf('Stimulus duration: %.0f ms\n', pa.stimDuration * 1000);
 fprintf('Flicker rate: %.0f Hz\n', pa.flickerHz);
 fprintf('ISI range: %.0f - %.0f s (mean %.1f s)\n', pa.isiMin, pa.isiMax, mean(pa.isiSequence));
 fprintf('Planned total: %.0f s (%.1f min)\n', pa.totalDesignDuration, pa.totalDesignDuration/60);
-fprintf('Dimming events: %d / %d ISIs\n', length(dimTrials), pa.nEvents);
+fprintf('Fixation dimming events: %d / %d ISIs\n', length(dimTrials), pa.nEvents);
 
 end


### PR DESCRIPTION
Follow-up to PR #100.\n\nChanges:\n- keep fixation cross red throughout the checkerboard task\n- remove fixation dimming schedule and ISI dimming logic\n- reduce fixation cross arm length from 0.25 to 0.20 visual degrees\n\nDesign remains 27 checkerboard presentations per run, 1 s each, 238 s total.