### PR TITLE
Tighten checkerboard flip timing

### DIFF
--- a/experiments/FMRI/qc/checkerboard/main.m
+++ b/experiments/FMRI/qc/checkerboard/main.m
@@ -94,22 +94,36 @@ try
     Screen('FillRect', VP.window, VP.backGroundColor);
     draw_fixation(VP, pa, pa.fixColor);
     vbl = Screen('Flip', VP.window);
-    WaitSecs(pa.initialBaselineDuration);
 
     % --- Event loop ---
     for ev = 1:pa.nEvents
+        plannedOnsetAbs = experimentStartTime + pa.plannedOnsets(ev);
+
+        while GetSecs < plannedOnsetAbs - 0.5 * VP.ifi
+            [pressed, firstPress] = KbQueueCheck();
+            if pressed && firstPress(kb.escKey)
+                fprintf('Terminated by user.\n');
+                error('user_abort');
+            end
+            WaitSecs(0.001);
+        end
+
         % --- Flash the checkerboard (contrast-reversing) ---
-        nFlipFrames = max(1, round(pa.stimDuration / VP.ifi));
-        for f = 1:nFlipFrames
-            phase = mod(floor((f - 1) * VP.ifi * pa.flickerHz * 2), 2);
+        eventEndAbs = plannedOnsetAbs + pa.stimDuration;
+        frameCount = 0;
+        eventOnset = NaN;
+        while GetSecs < eventEndAbs - 0.5 * VP.ifi
+            frameCount = frameCount + 1;
+            nowTime = GetSecs;
+            phase = mod(floor((nowTime - plannedOnsetAbs) * pa.flickerHz * 2), 2);
             if phase == 0
                 Screen('DrawTexture', VP.window, chk1);
             else
                 Screen('DrawTexture', VP.window, chk2);
             end
             draw_fixation(VP, pa, pa.fixColor);
-            if f == 1
-                vbl = Screen('Flip', VP.window);
+            if frameCount == 1
+                vbl = Screen('Flip', VP.window, plannedOnsetAbs - 0.5 * VP.ifi);
 
                 eventOnset = vbl - experimentStartTime;
                 fprintf('Event %d/%d (onset %.3f s)\n', ev, pa.nEvents, eventOnset);
@@ -126,27 +140,29 @@ try
         % --- ISI: fixation only ---
         Screen('FillRect', VP.window, VP.backGroundColor);
         draw_fixation(VP, pa, pa.fixColor);
-        vbl = Screen('Flip', VP.window, vbl + 0.5 * VP.ifi);
-
-        isiDuration = pa.isiSequence(ev);
-        isiEnd = GetSecs + isiDuration;
-
-        while GetSecs < isiEnd - 0.5 * VP.ifi
-            % Check escape
-            [pressed, firstPress] = KbQueueCheck();
-            if pressed && firstPress(kb.escKey)
-                fprintf('Terminated by user.\n');
-                error('user_abort');
-            end
-            WaitSecs(0.001);
+        vbl = Screen('Flip', VP.window, eventEndAbs - 0.5 * VP.ifi);
+        if ~isnan(eventOnset)
+            pa.events(pa.eventCounter).actual_duration = vbl - experimentStartTime - eventOnset;
+            pa.events(pa.eventCounter).planned_onset = pa.plannedOnsets(ev);
         end
     end
 
     % --- Final baseline ---
+    finalBaselineStartAbs = experimentStartTime + ...
+        pa.totalDesignDuration - pa.finalBaselineDuration;
+    while GetSecs < finalBaselineStartAbs - 0.5 * VP.ifi
+        [pressed, firstPress] = KbQueueCheck();
+        if pressed && firstPress(kb.escKey)
+            fprintf('Terminated by user.\n');
+            error('user_abort');
+        end
+        WaitSecs(0.001);
+    end
+
     Screen('FillRect', VP.window, VP.backGroundColor);
     draw_fixation(VP, pa, pa.fixColor);
-    Screen('Flip', VP.window);
-    WaitSecs(pa.finalBaselineDuration);
+    Screen('Flip', VP.window, finalBaselineStartAbs - 0.5 * VP.ifi);
+    WaitSecs('UntilTime', experimentStartTime + pa.totalDesignDuration);
 
     % End screen
     Screen('FillRect', VP.window, VP.backGroundColor);

--- a/experiments/FMRI/qc/checkerboard/main.m
+++ b/experiments/FMRI/qc/checkerboard/main.m
@@ -73,6 +73,13 @@ try
     fprintf('Checkerboard textures created (radius %.0f px, %d rings, %d wedges)\n', ...
         pa.checkerRadiusPix, pa.nRings, pa.nWedges);
 
+    % Touch both textures once before the scanner trigger so first stimulus
+    % presentation does not pay a one-time texture binding cost.
+    Screen('DrawTexture', VP.window, chk1);
+    Screen('DrawingFinished', VP.window);
+    Screen('DrawTexture', VP.window, chk2);
+    Screen('DrawingFinished', VP.window);
+
     wait_trigger(VP, debugConfig.manualTrigger);
 
     experimentStartTime = GetSecs;
@@ -86,43 +93,40 @@ try
     % --- Initial baseline fixation ---
     Screen('FillRect', VP.window, VP.backGroundColor);
     draw_fixation(VP, pa, pa.fixColor);
-    Screen('Flip', VP.window);
+    vbl = Screen('Flip', VP.window);
     WaitSecs(pa.initialBaselineDuration);
 
     % --- Event loop ---
     for ev = 1:pa.nEvents
-        eventOnset = GetSecs;
-        plannedOnset = eventOnset - experimentStartTime;
-
-        fprintf('Event %d/%d (onset %.1f s)\n', ev, pa.nEvents, plannedOnset);
-
-        % Log event
-        pa.eventCounter = pa.eventCounter + 1;
-        pa.events(pa.eventCounter).onset = plannedOnset;
-        pa.events(pa.eventCounter).duration = pa.stimDuration;
-        pa.events(pa.eventCounter).trial_type = 'checkerboard';
-
         % --- Flash the checkerboard (contrast-reversing) ---
-        nFlipFrames = round(pa.stimDuration * VP.frameRate);
-        framesPerPhase = max(1, round((1 / pa.flickerHz / 2) * VP.frameRate));
-        phase = 0;
+        nFlipFrames = max(1, round(pa.stimDuration / VP.ifi));
         for f = 1:nFlipFrames
-            if mod(f - 1, framesPerPhase) == 0
-                phase = 1 - phase;
-            end
+            phase = mod(floor((f - 1) * VP.ifi * pa.flickerHz * 2), 2);
             if phase == 0
                 Screen('DrawTexture', VP.window, chk1);
             else
                 Screen('DrawTexture', VP.window, chk2);
             end
             draw_fixation(VP, pa, pa.fixColor);
-            Screen('Flip', VP.window);
+            if f == 1
+                vbl = Screen('Flip', VP.window);
+
+                eventOnset = vbl - experimentStartTime;
+                fprintf('Event %d/%d (onset %.3f s)\n', ev, pa.nEvents, eventOnset);
+
+                pa.eventCounter = pa.eventCounter + 1;
+                pa.events(pa.eventCounter).onset = eventOnset;
+                pa.events(pa.eventCounter).duration = pa.stimDuration;
+                pa.events(pa.eventCounter).trial_type = 'checkerboard';
+            else
+                vbl = Screen('Flip', VP.window, vbl + 0.5 * VP.ifi);
+            end
         end
 
         % --- ISI: fixation only ---
         Screen('FillRect', VP.window, VP.backGroundColor);
         draw_fixation(VP, pa, pa.fixColor);
-        Screen('Flip', VP.window);
+        vbl = Screen('Flip', VP.window, vbl + 0.5 * VP.ifi);
 
         isiDuration = pa.isiSequence(ev);
         isiEnd = GetSecs + isiDuration;


### PR DESCRIPTION
Follow-up to PR #101.\n\nChanges:\n- warm up checkerboard textures before scanner trigger\n- schedule stimulus flips against the previous VBL\n- log event onset from the first actual stimulus flip\n- use time-based flicker phase selection to avoid an artificially long first/static phase\n\nThe design remains 27 presentations per run, 1 s each, 238 s total.