### PR TITLE
Fix checkerboard display timing

### DIFF
--- a/experiments/FMRI/qc/checkerboard/main.m
+++ b/experiments/FMRI/qc/checkerboard/main.m
@@ -70,8 +70,7 @@ kb = setup_keyboard();
 try
     % Pre-compute checkerboard textures (inside try so errors are caught)
     [chk1, chk2] = make_checkerboard_textures(VP, pa);
-    fprintf('Checkerboard textures created (radius %.0f px, %d rings, %d wedges)\n', ...
-        pa.checkerRadiusPix, pa.nRings, pa.nWedges);
+    fprintf('Checkerboard textures created (%.1f deg checks)\n', pa.checkSizeDeg);
 
     try
         Screen('PreloadTextures', VP.window, [chk1, chk2]);
@@ -108,21 +107,14 @@ try
 
         % --- Flash the checkerboard (contrast-reversing) ---
         eventEndAbs = plannedOnsetAbs + pa.stimDuration;
-        Screen('DrawTexture', VP.window, chk1);
-        draw_fixation(VP, pa, pa.fixColor);
-        vbl = Screen('Flip', VP.window, plannedOnsetAbs - 0.5 * VP.ifi);
+        eventOnset = NaN;
+        frameIndex = 0;
+        while true
+            nextFlipAbs = plannedOnsetAbs + frameIndex * VP.ifi;
+            if nextFlipAbs >= eventEndAbs - 0.5 * VP.ifi
+                break;
+            end
 
-        eventOnset = vbl - experimentStartTime;
-        fprintf('Event %d/%d (onset %.3f s)\n', ev, pa.nEvents, eventOnset);
-
-        pa.eventCounter = pa.eventCounter + 1;
-        pa.events(pa.eventCounter).onset = eventOnset;
-        pa.events(pa.eventCounter).duration = pa.stimDuration;
-        pa.events(pa.eventCounter).trial_type = 'checkerboard';
-
-        frameIndex = 1;
-        nextFlipAbs = plannedOnsetAbs + frameIndex * VP.ifi;
-        while nextFlipAbs < eventEndAbs - 0.5 * VP.ifi
             phase = mod(floor(frameIndex / pa.framesPerFlickerPhase), 2);
             if phase == 0
                 Screen('DrawTexture', VP.window, chk1);
@@ -132,16 +124,28 @@ try
             draw_fixation(VP, pa, pa.fixColor);
             vbl = Screen('Flip', VP.window, nextFlipAbs - 0.5 * VP.ifi);
 
+            if isnan(eventOnset)
+                eventOnset = vbl - experimentStartTime;
+                fprintf('Event %d/%d (onset %.3f s)\n', ev, pa.nEvents, eventOnset);
+
+                pa.eventCounter = pa.eventCounter + 1;
+                pa.events(pa.eventCounter).onset = eventOnset;
+                pa.events(pa.eventCounter).duration = pa.stimDuration;
+                pa.events(pa.eventCounter).trial_type = 'checkerboard';
+            end
+
             frameIndex = max(frameIndex + 1, floor((vbl - plannedOnsetAbs) / VP.ifi) + 1);
-            nextFlipAbs = plannedOnsetAbs + frameIndex * VP.ifi;
         end
 
         % --- ISI: fixation only ---
         Screen('FillRect', VP.window, VP.backGroundColor);
         draw_fixation(VP, pa, pa.fixColor);
         vbl = Screen('Flip', VP.window, eventEndAbs - 0.5 * VP.ifi);
-        pa.events(pa.eventCounter).actual_duration = vbl - experimentStartTime - eventOnset;
-        pa.events(pa.eventCounter).planned_onset = pa.plannedOnsets(ev);
+        if ~isnan(eventOnset)
+            pa.events(pa.eventCounter).actual_duration = vbl - experimentStartTime - eventOnset;
+            pa.events(pa.eventCounter).planned_onset = pa.plannedOnsets(ev);
+            fprintf('  actual duration %.3f s\n', pa.events(pa.eventCounter).actual_duration);
+        end
     end
 
     % --- Final baseline ---
@@ -203,36 +207,22 @@ end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 function [tex1, tex2] = make_checkerboard_textures(VP, pa)
-% MAKE_CHECKERBOARD_TEXTURES - Create two phase-inverted radial checkerboards.
+% MAKE_CHECKERBOARD_TEXTURES - Create two phase-inverted Cartesian checkerboards.
 
 w = round(VP.windowWidthPix);
 h = round(VP.windowHeightPix);
-halfW = w / 2;
-halfH = h / 2;
+checkSizePix = max(1, round(pa.checkSizeDeg * VP.pixelsPerDegree));
+[xx, yy] = meshgrid(0:w-1, 0:h-1);
 
-[xx, yy] = meshgrid(linspace(-halfW, halfW, w), linspace(-halfH, halfH, h));
-r = sqrt(xx.^2 + yy.^2);
-theta = atan2(yy, xx);
-
-% Equal-width rings within the stimulus aperture.
-ringPhase = floor(r / pa.checkerRadiusPix * pa.nRings);
-ringPhase(r >= pa.checkerRadiusPix) = pa.nRings - 1;
-
-% Angular wedges
-wedgePhase = floor((theta + pi) / (2*pi) * pa.nWedges);
-
-% Checkerboard pattern
-pattern = mod(ringPhase + wedgePhase, 2);
-
-% Circular aperture
-inField = r <= pa.checkerRadiusPix;
+% Full-field Cartesian checkerboard.
+pattern = mod(floor(xx / checkSizePix) + floor(yy / checkSizePix), 2);
 
 % Phase 1: white checks on black
 img1 = uint8(VP.backGroundColor(1) * ones(h, w, 3));
 for ch = 1:3
     plane = img1(:,:,ch);
-    plane(inField & pattern == 1) = 255;
-    plane(inField & pattern == 0) = 0;
+    plane(pattern == 1) = 255;
+    plane(pattern == 0) = 0;
     img1(:,:,ch) = plane;
 end
 
@@ -240,8 +230,8 @@ end
 img2 = uint8(VP.backGroundColor(1) * ones(h, w, 3));
 for ch = 1:3
     plane = img2(:,:,ch);
-    plane(inField & pattern == 1) = 0;
-    plane(inField & pattern == 0) = 255;
+    plane(pattern == 1) = 0;
+    plane(pattern == 0) = 255;
     img2(:,:,ch) = plane;
 end
 

--- a/experiments/FMRI/qc/checkerboard/main.m
+++ b/experiments/FMRI/qc/checkerboard/main.m
@@ -73,12 +73,10 @@ try
     fprintf('Checkerboard textures created (radius %.0f px, %d rings, %d wedges)\n', ...
         pa.checkerRadiusPix, pa.nRings, pa.nWedges);
 
-    % Touch both textures once before the scanner trigger so first stimulus
-    % presentation does not pay a one-time texture binding cost.
-    Screen('DrawTexture', VP.window, chk1);
-    Screen('DrawingFinished', VP.window);
-    Screen('DrawTexture', VP.window, chk2);
-    Screen('DrawingFinished', VP.window);
+    try
+        Screen('PreloadTextures', VP.window, [chk1, chk2]);
+    catch
+    end
 
     wait_trigger(VP, debugConfig.manualTrigger);
 
@@ -115,7 +113,7 @@ try
         while GetSecs < eventEndAbs - 0.5 * VP.ifi
             frameCount = frameCount + 1;
             nowTime = GetSecs;
-            phase = mod(floor((nowTime - plannedOnsetAbs) * pa.flickerHz * 2), 2);
+            phase = mod(floor((nowTime - plannedOnsetAbs) * pa.actualFlickerHz * 2), 2);
             if phase == 0
                 Screen('DrawTexture', VP.window, chk1);
             else
@@ -217,11 +215,9 @@ halfH = h / 2;
 r = sqrt(xx.^2 + yy.^2);
 theta = atan2(yy, xx);
 
-% Radial rings (log-spaced for roughly equal cortical magnification)
-maxR = max(halfW, halfH);
-logR = log(r + 1);
-logMax = log(maxR + 1);
-ringPhase = floor(logR / logMax * pa.nRings);
+% Equal-width rings within the stimulus aperture.
+ringPhase = floor(r / pa.checkerRadiusPix * pa.nRings);
+ringPhase(r >= pa.checkerRadiusPix) = pa.nRings - 1;
 
 % Angular wedges
 wedgePhase = floor((theta + pi) / (2*pi) * pa.nWedges);

--- a/experiments/FMRI/qc/checkerboard/main.m
+++ b/experiments/FMRI/qc/checkerboard/main.m
@@ -77,6 +77,7 @@ try
     catch
     end
 
+    ListenChar(2);  % suppress keyboard input to MATLAB editor
     wait_trigger(VP, debugConfig.manualTrigger);
 
     experimentStartTime = GetSecs;
@@ -126,15 +127,17 @@ try
 
             if isnan(eventOnset)
                 eventOnset = vbl - experimentStartTime;
-                fprintf('Event %d/%d (onset %.3f s)\n', ev, pa.nEvents, eventOnset);
-
-                pa.eventCounter = pa.eventCounter + 1;
-                pa.events(pa.eventCounter).onset = eventOnset;
-                pa.events(pa.eventCounter).duration = pa.stimDuration;
-                pa.events(pa.eventCounter).trial_type = 'checkerboard';
             end
 
             frameIndex = max(frameIndex + 1, floor((vbl - plannedOnsetAbs) / VP.ifi) + 1);
+        end
+
+        % Log event
+        if ~isnan(eventOnset)
+            pa.eventCounter = pa.eventCounter + 1;
+            pa.events(pa.eventCounter).onset = eventOnset;
+            pa.events(pa.eventCounter).duration = pa.stimDuration;
+            pa.events(pa.eventCounter).trial_type = 'checkerboard';
         end
 
         % --- ISI: fixation only ---

--- a/experiments/FMRI/qc/checkerboard/main.m
+++ b/experiments/FMRI/qc/checkerboard/main.m
@@ -91,7 +91,7 @@ try
     % --- Initial baseline fixation ---
     Screen('FillRect', VP.window, VP.backGroundColor);
     draw_fixation(VP, pa, pa.fixColor);
-    vbl = Screen('Flip', VP.window);
+    Screen('Flip', VP.window);
 
     % --- Event loop ---
     for ev = 1:pa.nEvents
@@ -108,41 +108,40 @@ try
 
         % --- Flash the checkerboard (contrast-reversing) ---
         eventEndAbs = plannedOnsetAbs + pa.stimDuration;
-        frameCount = 0;
-        eventOnset = NaN;
-        while GetSecs < eventEndAbs - 0.5 * VP.ifi
-            frameCount = frameCount + 1;
-            nowTime = GetSecs;
-            phase = mod(floor((nowTime - plannedOnsetAbs) * pa.actualFlickerHz * 2), 2);
+        Screen('DrawTexture', VP.window, chk1);
+        draw_fixation(VP, pa, pa.fixColor);
+        vbl = Screen('Flip', VP.window, plannedOnsetAbs - 0.5 * VP.ifi);
+
+        eventOnset = vbl - experimentStartTime;
+        fprintf('Event %d/%d (onset %.3f s)\n', ev, pa.nEvents, eventOnset);
+
+        pa.eventCounter = pa.eventCounter + 1;
+        pa.events(pa.eventCounter).onset = eventOnset;
+        pa.events(pa.eventCounter).duration = pa.stimDuration;
+        pa.events(pa.eventCounter).trial_type = 'checkerboard';
+
+        frameIndex = 1;
+        nextFlipAbs = plannedOnsetAbs + frameIndex * VP.ifi;
+        while nextFlipAbs < eventEndAbs - 0.5 * VP.ifi
+            phase = mod(floor(frameIndex / pa.framesPerFlickerPhase), 2);
             if phase == 0
                 Screen('DrawTexture', VP.window, chk1);
             else
                 Screen('DrawTexture', VP.window, chk2);
             end
             draw_fixation(VP, pa, pa.fixColor);
-            if frameCount == 1
-                vbl = Screen('Flip', VP.window, plannedOnsetAbs - 0.5 * VP.ifi);
+            vbl = Screen('Flip', VP.window, nextFlipAbs - 0.5 * VP.ifi);
 
-                eventOnset = vbl - experimentStartTime;
-                fprintf('Event %d/%d (onset %.3f s)\n', ev, pa.nEvents, eventOnset);
-
-                pa.eventCounter = pa.eventCounter + 1;
-                pa.events(pa.eventCounter).onset = eventOnset;
-                pa.events(pa.eventCounter).duration = pa.stimDuration;
-                pa.events(pa.eventCounter).trial_type = 'checkerboard';
-            else
-                vbl = Screen('Flip', VP.window, vbl + 0.5 * VP.ifi);
-            end
+            frameIndex = max(frameIndex + 1, floor((vbl - plannedOnsetAbs) / VP.ifi) + 1);
+            nextFlipAbs = plannedOnsetAbs + frameIndex * VP.ifi;
         end
 
         % --- ISI: fixation only ---
         Screen('FillRect', VP.window, VP.backGroundColor);
         draw_fixation(VP, pa, pa.fixColor);
         vbl = Screen('Flip', VP.window, eventEndAbs - 0.5 * VP.ifi);
-        if ~isnan(eventOnset)
-            pa.events(pa.eventCounter).actual_duration = vbl - experimentStartTime - eventOnset;
-            pa.events(pa.eventCounter).planned_onset = pa.plannedOnsets(ev);
-        end
+        pa.events(pa.eventCounter).actual_duration = vbl - experimentStartTime - eventOnset;
+        pa.events(pa.eventCounter).planned_onset = pa.plannedOnsets(ev);
     end
 
     % --- Final baseline ---

--- a/experiments/FMRI/qc/checkerboard/utils/setup/setup_param.m
+++ b/experiments/FMRI/qc/checkerboard/utils/setup/setup_param.m
@@ -47,10 +47,7 @@ pa.totalDesignDuration = design.totalDesignDuration;
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % CHECKERBOARD PARAMETERS
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-pa.checkerRadiusDeg = 12;       % radius of checkerboard in degrees
-pa.checkerRadiusPix = pa.checkerRadiusDeg * VP.pixelsPerDegree;
-pa.nRings = 10;                 % number of equal-width concentric rings
-pa.nWedges = 24;                % number of angular wedges
+pa.checkSizeDeg = 1.0;          % full-field Cartesian check size
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % FIXATION CROSS

--- a/experiments/FMRI/qc/checkerboard/utils/setup/setup_param.m
+++ b/experiments/FMRI/qc/checkerboard/utils/setup/setup_param.m
@@ -31,6 +31,8 @@ pa.designSeed = design.designSeed;
 pa.targetRunDuration = design.targetRunDuration;
 pa.stimDuration = design.stimDuration;
 pa.flickerHz = design.flickerHz;
+pa.framesPerFlickerPhase = max(1, round(VP.frameRate / (2 * pa.flickerHz)));
+pa.actualFlickerHz = VP.frameRate / (2 * pa.framesPerFlickerPhase);
 pa.isiMin = design.isiMin;
 pa.isiMax = design.isiMax;
 pa.nEvents = design.nEvents;
@@ -47,7 +49,7 @@ pa.totalDesignDuration = design.totalDesignDuration;
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 pa.checkerRadiusDeg = 12;       % radius of checkerboard in degrees
 pa.checkerRadiusPix = pa.checkerRadiusDeg * VP.pixelsPerDegree;
-pa.nRings = 10;                 % number of concentric rings (log-spaced)
+pa.nRings = 10;                 % number of equal-width concentric rings
 pa.nWedges = 24;                % number of angular wedges
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -100,7 +102,9 @@ fprintf('=== Checkerboard HRF Estimation ===\n');
 fprintf('Design: %s (seed %d)\n', pa.designID, pa.designSeed);
 fprintf('Events: %d\n', pa.nEvents);
 fprintf('Stimulus duration: %.0f ms\n', pa.stimDuration * 1000);
-fprintf('Flicker rate: %.0f Hz\n', pa.flickerHz);
+fprintf('Requested flicker rate: %.1f Hz\n', pa.flickerHz);
+fprintf('Displayed flicker rate: %.2f Hz (%d frames/phase at %.2f Hz refresh)\n', ...
+    pa.actualFlickerHz, pa.framesPerFlickerPhase, VP.frameRate);
 fprintf('ISI range: %.0f - %.0f s (mean %.1f s)\n', pa.isiMin, pa.isiMax, mean(pa.isiSequence));
 fprintf('Planned total: %.0f s (%.1f min)\n', pa.totalDesignDuration, pa.totalDesignDuration/60);
 fprintf('Fixation dimming events: %d / %d ISIs\n', length(dimTrials), pa.nEvents);


### PR DESCRIPTION
Fixes display regressions in the checkerboard task.\n\nChanges:\n- remove visible pre-trigger checkerboard texture warm-up\n- preload textures without drawing them before the trigger screen\n- use equal-width radial rings within the aperture\n- snap flicker timing to a refresh-compatible phase duration and report the actual displayed flicker rate